### PR TITLE
Stylelint prettier and a fix

### DIFF
--- a/apps/examples/basic-starter/package.json
+++ b/apps/examples/basic-starter/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint 'src/**/*.{ts,tsx}' && stylelint 'src/**/*.{css,scss}'",
     "lint:fix": "eslint 'src/**/*.{js,ts,tsx}' --fix && stylelint 'src/**/*.{css,scss}' --fix",
-    "format": "prettier --write  'src/**/*.{js,ts,tsx}'",
+    "format": "prettier --write  'src/**/*.{js,ts,tsx,scss}'",
     "prepare": "husky install",
     "analyze": "ANALYZE=1 yarn build"
   },

--- a/apps/examples/default-starter/package.json
+++ b/apps/examples/default-starter/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint 'src/**/*.{ts,tsx,graphql}' && stylelint 'src/**/*.{css,scss}'",
     "lint:fix": "eslint 'src/**/*.{js,ts,tsx,graphql}' --fix && stylelint 'src/**/*.{css,scss}' --fix",
-    "format": "prettier --write  'src/**/*.{js,ts,tsx}'",
+    "format": "prettier --write  'src/**/*.{js,ts,tsx,scss}'",
     "prepare": "husky install",
     "analyze": "ANALYZE=1 yarn build",
     "storybook": "start-storybook -p 6006 -s public",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint:fix",
-    "format": "prettier --write \"**/*.{js,ts,tsx,md}\"",
+    "format": "prettier --write \"**/*.{js,ts,tsx,md,scss}\"",
     "prepare": "husky install",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test"

--- a/packages/gen/src/component/genComponent.ts
+++ b/packages/gen/src/component/genComponent.ts
@@ -3,7 +3,7 @@ import cpy from 'cpy';
 import path from 'path';
 import chalk from 'chalk';
 import fs from 'fs/promises';
-import toTitleCase from '../utils/toTitleCase';
+import toPascalCase from '../utils/toPascalCase';
 
 const questions: PromptObject[] = [
   {
@@ -59,7 +59,7 @@ export default async function genComponent() {
 }
 
 async function createComponent(options: Answers<string>) {
-  const name = toTitleCase(options.name);
+  const name = toPascalCase(options.name);
   const componentTemplatePath = path.join(
     __dirname,
     '/templates/Component.tsx'

--- a/packages/gen/src/utils/toPascalCase.ts
+++ b/packages/gen/src/utils/toPascalCase.ts
@@ -1,0 +1,5 @@
+export default function toPascalCase(str: string) {
+  return str.replace(/\w\S*/g, txt => {
+    return txt.charAt(0).toUpperCase() + txt.substr(1);
+  });
+}

--- a/packages/gen/src/utils/toTitleCase.ts
+++ b/packages/gen/src/utils/toTitleCase.ts
@@ -1,5 +1,0 @@
-export default function toTitleCase(str: string) {
-  return str.replace(/\w\S*/g, txt => {
-    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
-  });
-}

--- a/packages/stylelint-config/base.js
+++ b/packages/stylelint-config/base.js
@@ -1,25 +1,11 @@
 /** @type {import('stylelint').Config} */
 const config = {
   extends: ['stylelint-config-standard', 'stylelint-config-prettier'],
-  plugins: ['stylelint-order'],
+  plugins: ['stylelint-order', 'stylelint-prettier'],
   rules: {
     // alphabetic order
     'order/order': ['custom-properties', 'declarations'],
     'order/properties-alphabetical-order': true,
-
-    // formatting
-    'declaration-colon-newline-after': 'always-multi-line',
-    'rule-empty-line-before': [
-      'always',
-      { except: ['first-nested', 'after-single-line-comment'] },
-    ],
-    'at-rule-empty-line-before': [
-      'always',
-      { except: ['first-nested', 'blockless-after-same-name-blockless'] },
-    ],
-    'declaration-empty-line-before': 'never',
-    'declaration-no-important': true,
-
     // mobile first
     'media-feature-name-disallowed-list': [
       'max-width',
@@ -27,9 +13,9 @@ const config = {
         message: 'Use min-width for a mobile-first approach',
       },
     ],
-
     // works with a systemic design - disable if impractical in a specific project
     'color-named': 'always-where-possible',
+    'prettier/prettier': true,
   },
 };
 

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -15,6 +15,7 @@
     "stylelint-config-prettier": "^9.0.3",
     "stylelint-config-standard-scss": "^3.0.0",
     "stylelint-order": "^5.0.0",
+    "stylelint-prettier": "^2.0.0",
     "stylelint-scss": "^4.2.0"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6941,6 +6941,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
+
 fast-glob@^2.2.6:
   version "2.2.7"
   resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz#6953857c3afa475fff92ee6015d52da70a4cd39d"
@@ -10961,6 +10966,13 @@ prelude-ls@~1.1.2:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
 "prettier@>=2.2.1 <=2.3.0":
   version "2.3.0"
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
@@ -12640,6 +12652,13 @@ stylelint-order@^5.0.0:
   dependencies:
     postcss "^8.3.11"
     postcss-sorting "^7.0.1"
+
+stylelint-prettier@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-prettier/-/stylelint-prettier-2.0.0.tgz#ead781aea522379f2ffa2d136bafdfc451d699a5"
+  integrity sha512-jvT3G+9lopkeB0ARmDPszyfaOnvnIF+30QCjZxyt7E6fynI1T9mOKgYDNb9bXX17M7PXMZaX3j/26wqakjp1tw==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
 
 stylelint-scss@^4.0.0, stylelint-scss@^4.2.0:
   version "4.3.0"


### PR DESCRIPTION
Drop formatting rules from stylelint-config; use Prettier instead.
Also, fix an unintended behavior in generating a component (title case should be pascal case).